### PR TITLE
Add `glfwPostEmptyEvent` function definition for CFFI

### DIFF
--- a/cl-glfw3.lisp
+++ b/cl-glfw3.lisp
@@ -316,7 +316,7 @@ SHARED: The window whose context to share resources with."
   (%glfw:set-framebuffer-size-callback window (cffi:get-callback callback-name)))
 
 ;;;; ## Events and input
-(import-export %glfw:poll-events %glfw:wait-events)
+(import-export %glfw:poll-events %glfw:wait-events %glfw:post-empty-event)
 
 (defun get-input-mode (mode &optional (window *window*))
   "Mode is one of :CURSOR :STICKY-KEYS or :STICKY-MOUSE-BUTTONS."

--- a/glfw-bindings.lisp
+++ b/glfw-bindings.lisp
@@ -50,6 +50,7 @@
    set-framebuffer-size-callback
    poll-events
    wait-events
+   post-empty-event
    get-input-mode
    set-input-mode
    get-key
@@ -84,10 +85,10 @@
 (define-foreign-library (glfw)
      (:darwin (:or
                ; homebrew naming
-               "libglfw3.0.dylib" "libglfw3.dylib"
+               "libglfw3.1.dylib" "libglfw3.dylib"
                ; cmake build naming
-               "libglfw.3.0.dylib" "libglfw.3.dylib"))
-     (:unix (:or "libglfw.so.3.0" "libglfw.so.3"))
+               "libglfw.3.1.dylib" "libglfw.3.dylib"))
+     (:unix (:or "libglfw.so.3.1" "libglfw.so.3"))
      (t (:or (:default "libglfw3") (:default "libglfw"))))
 
 (use-foreign-library glfw)
@@ -605,6 +606,8 @@ Returns previously set callback."
 (defcfun ("glfwPollEvents" poll-events) (float-traps-masked :void))
 
 (defcfun ("glfwWaitEvents" wait-events) (float-traps-masked :void))
+
+(defcfun ("glfwPostEmptyEvent" post-empty-event) :void)
 
 (defcfun ("glfwGetInputMode" get-input-mode) :int
   (window window) (mode input-mode))


### PR DESCRIPTION
Bump `glfw` minor version

[`glfwPostEmptyEvent`](http://www.glfw.org/docs/latest/group__window.html#gab5997a25187e9fd5c6f2ecbbc8dfd7e9) function is particularly useful when used in pair with `glfwWaitEvents` to wake up waiting event loop. E.g. when closing window by some internal logic (while setting `glfwSetWindowShouldClose`) instead of waiting for any other random `glfw` event to come, one can just call `glfwPostEmptyEvent` and `glfwWaitEvents` will return asap.

This function was introduced in `glfw` 3.1, hence the minor version bump.