### PR TITLE
set-window-monitor function

### DIFF
--- a/cl-glfw3.lisp
+++ b/cl-glfw3.lisp
@@ -31,6 +31,7 @@
    set-window-position
    get-window-size
    set-window-size
+   set-window-monitor
    get-framebuffer-size
    iconify-window
    restore-window
@@ -158,7 +159,7 @@
 MONITOR: The monitor on which the window should be full-screen.
 SHARED: The window whose context to share resources with."
   (macrolet ((output-hints (&rest hints)
-	       `(progn 
+	       `(progn
 		  ,@(loop for (name type) in hints collect
 			 `(%glfw:window-hint
 			   ,(intern (string-upcase
@@ -230,6 +231,12 @@ SHARED: The window whose context to share resources with."
 
 (defun get-framebuffer-size (&optional (window *window*))
   (%glfw:get-framebuffer-size window))
+
+(defun set-window-monitor (monitor width height &key (window *window*)
+                                                  (x-position 0) (y-position 0)
+                                                  (refresh-rate %glfw:+dont-care+))
+  (let ((monitor (if (null monitor) (cffi:null-pointer) monitor)))
+    (%glfw:set-window-monitor window monitor x-position y-position width height refresh-rate)))
 
 (defun iconify-window (&optional (window *window*))
   (%glfw:iconify-window window))

--- a/glfw-bindings.lisp
+++ b/glfw-bindings.lisp
@@ -5,7 +5,8 @@
 (in-package #:%glfw)
 
 (export
- '(init
+ '(+dont-care+
+   init
    terminate
    get-version
    get-version-string
@@ -18,6 +19,9 @@
    set-monitor-callback
    get-video-modes
    get-video-mode
+   video-mode
+   width
+   height
    set-gamma
    get-gamma-ramp
    set-gamma-ramp
@@ -48,6 +52,7 @@
    set-window-focus-callback
    set-window-iconify-callback
    set-framebuffer-size-callback
+   set-window-monitor
    poll-events
    wait-events
    post-empty-event
@@ -165,6 +170,8 @@ CFFI's defcallback that takes care of GLFW specifics."
 
 (defun c-array->list (array count &optional (type :pointer))
   (loop for i below count collect (mem-aref array type i)))
+
+(alexandria:define-constant +dont-care+ -1)
 
 ;;;; ## GLFW Types
 (defcenum (key-action)
@@ -515,6 +522,11 @@ Returns previously set callback."
 
 (defcfun ("glfwSetWindowTitle" set-window-title) :void
   (window window) (title :string))
+
+(defcfun ("glfwSetWindowMonitor" set-window-monitor) :void
+    (window window) (monitor monitor)
+    (x-position :int) (y-position :int)
+    (width :int) (height :int) (refresh-rate :int))
 
 (defun get-window-position (window)
   "Returns position of upper left corner of window (x y) in screen coordinates."


### PR DESCRIPTION
Useful for setting fullscreen mode on/off dynamically.

Example usage:
```lisp
(if fullscreen-p
    (let* ((monitor (glfw:get-primary-monitor))
           (video-mode (%glfw:get-video-mode monitor))
           (width (getf video-mode '%glfw:width))
           (height (getf video-mode '%glfw:height)))
      (glfw:set-window-monitor monitor width height :window window))
    (glfw:set-window-monitor nil 640 480 :window window :x-position 100 :y-position 100))
```