### PR TITLE
removed cffi-libffi dependency

### DIFF
--- a/cl-glfw3.asd
+++ b/cl-glfw3.asd
@@ -5,7 +5,7 @@
   :description "Bindings for GLFW 3.x"
   :author "Alex Charlton <alex.n.charlton@gmail.com>"
   :license "BSD-2"
-  :depends-on (#:cffi #:cffi-libffi #:alexandria)
+  :depends-on (#:cffi #:alexandria)
   :components ((:file "package")
                (:file "glfw-bindings")
                (:file "cl-glfw3")))

--- a/glfw-bindings.lisp
+++ b/glfw-bindings.lisp
@@ -499,7 +499,7 @@ Returns previously set callback."
            '(:struct gamma-ramp)))
 
 (defcfun ("glfwSetGammaRamp" set-gamma-ramp) :void
-  (monitor monitor) (ramp (:struct gamma-ramp)))
+  (monitor monitor) (ramp gamma-ramp))
 
 (defcfun ("glfwDefaultWindowHints" default-window-hints) :void
   "Reset all window hints to defaults.")


### PR DESCRIPTION
This fixes ARM compatibility for me; see issue #16. But, I need approval on the solution.

Before:
```
(defcfun ("glfwSetGammaRamp" set-gamma-ramp) :void
  (monitor monitor) (ramp (:struct gamma-ramp)))
```
After:
```
(defcfun ("glfwSetGammaRamp" set-gamma-ramp) :void
  (monitor monitor) (ramp gamma-ramp))
```

By not passing `gamma-ramp` struct by value, we remove the `cffi-libffi` dependency. However, it may be possible to pass by value without using the `cffi-libffi` syntax. Thoughts?