### PR TITLE
issue/18: added reference to glfw3.dll for windows users

### DIFF
--- a/glfw-bindings.lisp
+++ b/glfw-bindings.lisp
@@ -94,6 +94,7 @@
                ; cmake build naming
                "libglfw.3.1.dylib" "libglfw.3.dylib"))
      (:unix (:or "libglfw.so.3.1" "libglfw.so.3"))
+     (:windows "glfw3.dll")
      (t (:or (:default "libglfw3") (:default "libglfw"))))
 
 (use-foreign-library glfw)


### PR DESCRIPTION
This was preventing me from getting basic-window-example running. 