### PR TITLE
Create window by functional return of parameters

### DIFF
--- a/cl-glfw3-examples.asd
+++ b/cl-glfw3-examples.asd
@@ -1,14 +1,14 @@
 ;;;; cl-glfw3-examples.asd
 
-(asdf:defsystem #:cl-glfw3-examples
+(asdf:defsystem :cl-glfw3-examples
   :serial t
   :description "Examples for cl-glfw3"
   :author "Alex Charlton <alex.n.charlton@gmail.com>"
   :license "BSD-2"
-  :depends-on (#:cl-glfw3 #:cl-opengl #:trivial-main-thread)
-  :pathname "examples/"
-  :components ((:file "package")
-               (:file "basic-window")
-               (:file "fragment-shader")
-               (:file "particles-basic")
-               (:file "events")))
+  :class :package-inferred-system
+  :defsystem-depends-on (:asdf-package-system)
+  :depends-on (#:cl-glfw3
+                #:cl-opengl
+                #:trivial-main-thread
+
+                :cl-glfw3-examples/examples/package))

--- a/cl-glfw3.lisp
+++ b/cl-glfw3.lisp
@@ -210,17 +210,15 @@ SHARED: The window whose context to share resources with."
    "
   `(unwind-protect
      (progn
-       ,(cond
+       ,(if (fboundp (car keys))
 
-          ;; Dealing with a function?
+          ;; Dealing with a function
           ;; (with-window (my-function))
-          ((fboundp (car keys))
-            `(apply #'create-window ,window-keys))
-
+          `(apply #'create-window ,window-keys)
 
           ;; Dealing with a symbol
           ;; (with-window (:width 100 :height 200))
-          (t `(create-window ,@window-keys)))
+          `(create-window ,@window-keys))
 
        ,@body)
      (destroy-window)))

--- a/cl-glfw3.lisp
+++ b/cl-glfw3.lisp
@@ -196,31 +196,11 @@ SHARED: The window whose context to share resources with."
     (setf *window* nil)))
 
 (defmacro with-window ((&rest window-keys) &body body)
-  "Passed a function which returns a list of parameters,
-   create a new window from those parameters.
-
-   ;; Where (params-list-or-func my-object) => (:width 100 :height 200 :title \"My title\")
-   (with-window-from-list (params-func my-object)
-     (loop ...))
-
-   OR, pass a list
-
-   (with-window-from-list (:width 100 :height 100 :title \"My title\")
-     (loop ...))
-   "
+  "Convenience macro for using windows."
   `(unwind-protect
-     (progn
-       ,(if (fboundp (car keys))
-
-          ;; Dealing with a function
-          ;; (with-window (my-function))
-          `(apply #'create-window ,window-keys)
-
-          ;; Dealing with a symbol
-          ;; (with-window (:width 100 :height 200))
-          `(create-window ,@window-keys))
-
-       ,@body)
+	(progn
+	  (create-window ,@window-keys)
+	  ,@body)
      (destroy-window)))
 
 (defmacro with-init-window ((&rest window-keys) &body body)

--- a/cl-glfw3.lisp
+++ b/cl-glfw3.lisp
@@ -212,9 +212,9 @@ SHARED: The window whose context to share resources with."
 
    Where (params-function my-object) => (:width 100 :height 200 :title \"My title\")"
   `(unwind-protect
-        (progn
-          (apply #'glfw:create-window ,params-function)
-          ,@body)
+     (progn
+       (apply #'glfw:create-window ,params-function)
+       ,@body)
      (glfw:destroy-window)))
 
 (defmacro with-init-window ((&rest window-keys) &body body)

--- a/cl-glfw3.lisp
+++ b/cl-glfw3.lisp
@@ -228,7 +228,7 @@ SHARED: The window whose context to share resources with."
      (with-window ,window-keys ,@body)))
 
 (defmacro with-init-window-from-list (params-list-or-func &body body)
-  "Convience helper for functional return of window parameters
+  "Convenience helper for functional return of window parameters
    Where (params-function) => (:width 100 :height 200 :title \"My title\")"
   `(with-init
      (with-window-from-func ,params-list-or-func ,@body)))

--- a/cl-glfw3.lisp
+++ b/cl-glfw3.lisp
@@ -203,17 +203,22 @@ SHARED: The window whose context to share resources with."
 	  ,@body)
      (destroy-window)))
 
-(defmacro with-window-from-func (params-function &rest body)
-  "Passed a function which returns a list of parameters,
+(defmacro with-window-from-list (params-list-or-func &rest body)
+  "Passed a list or a function which returns a list of parameters,
    create a new window from those parameters.
 
-   (with-window-from-func (params-function my-object)
+   ;; Where (params-list-or-func my-object) => (:width 100 :height 200 :title \"My title\")
+   (with-window-from-list (params-func my-object)
      (loop ...))
 
-   Where (params-function my-object) => (:width 100 :height 200 :title \"My title\")"
+   OR, pass a list
+
+   (with-window-from-list '(:width 100 :height 100 :title \"My title\")
+     (loop ...))
+   "
   `(unwind-protect
      (progn
-       (apply #'glfw:create-window ,params-function)
+       (apply #'glfw:create-window ,params-list-or-func)
        ,@body)
      (glfw:destroy-window)))
 
@@ -222,11 +227,11 @@ SHARED: The window whose context to share resources with."
   `(with-init
      (with-window ,window-keys ,@body)))
 
-(defmacro with-init-window-from-func (params-function &body body)
+(defmacro with-init-window-from-list (params-list-or-func &body body)
   "Convience helper for functional return of window parameters
    Where (params-function) => (:width 100 :height 200 :title \"My title\")"
   `(with-init
-     (with-window-from-func ,window-keys ,@body)))
+     (with-window-from-func ,params-list-or-func ,@body)))
 
 (defun window-should-close-p (&optional (window *window*))
   (%glfw:window-should-close-p window))

--- a/cl-glfw3.lisp
+++ b/cl-glfw3.lisp
@@ -203,10 +203,30 @@ SHARED: The window whose context to share resources with."
 	  ,@body)
      (destroy-window)))
 
+(defmacro with-window-from-func (params-function &rest body)
+  "Passed a function which returns a list of parameters,
+   create a new window from those parameters.
+
+   (with-window-from-func (params-function my-object)
+     (loop ...))
+
+   Where (params-function my-object) => (:width 100 :height 200 :title \"My title\")"
+  `(unwind-protect
+        (progn
+          (apply #'glfw:create-window ,params-function)
+          ,@body)
+     (glfw:destroy-window)))
+
 (defmacro with-init-window ((&rest window-keys) &body body)
   "Convenience macro for setting up GLFW and opening a window."
   `(with-init
      (with-window ,window-keys ,@body)))
+
+(defmacro with-init-window-from-func (params-function &body body)
+  "Convience helper for functional return of window parameters
+   Where (params-function) => (:width 100 :height 200 :title \"My title\")"
+  `(with-init
+     (with-window-from-func ,window-keys ,@body)))
 
 (defun window-should-close-p (&optional (window *window*))
   (%glfw:window-should-close-p window))

--- a/examples/basic-window.lisp
+++ b/examples/basic-window.lisp
@@ -30,14 +30,11 @@
   (declare (ignore window))
   (set-viewport w h))
 
-(defun get-window-parameters ()
-  '(:title "Window test" :width 600 :height 400))
-
 (defun basic-window-example ()
   ;; Graphics calls on OS X must occur in the main thread
   (tmt:with-body-in-main-thread ()
     (glfw:with-init-window (:title "Window test" :width 600 :height 400)
-      ;(setf %gl:*gl-get-proc-address* #'get-proc-address)
+
       (glfw:set-key-callback 'quit-on-escape)
       (glfw:set-window-size-callback 'update-viewport)
       (gl:clear-color 0 0 0 0)

--- a/examples/basic-window.lisp
+++ b/examples/basic-window.lisp
@@ -1,13 +1,16 @@
 ;;;; basic-window.lisp
 ;;;; OpenGL example code borrowed from cl-opengl
-(in-package #:cl-glfw3-examples)
 
-(export '(basic-window-example))
+(defpackage :cl-glfw3-examples/examples/basic-window
+  (:use :cl :trivial-main-thread)
+  (:export #:basic-window-example))
 
-(def-key-callback quit-on-escape (window key scancode action mod-keys)
+(in-package :cl-glfw3-examples/examples/basic-window)
+
+(glfw:def-key-callback quit-on-escape (window key scancode action mod-keys)
   (declare (ignore window scancode mod-keys))
   (when (and (eq key :escape) (eq action :press))
-    (set-window-should-close)))
+    (glfw:set-window-should-close)))
 
 (defun render ()
   (gl:clear :color-buffer)
@@ -23,20 +26,24 @@
   (gl:matrix-mode :modelview)
   (gl:load-identity))
 
-(def-window-size-callback update-viewport (window w h)
+(glfw:def-window-size-callback update-viewport (window w h)
   (declare (ignore window))
   (set-viewport w h))
 
+(defun get-window-parameters ()
+  '(:title "Window test" :width 600 :height 400))
+
 (defun basic-window-example ()
   ;; Graphics calls on OS X must occur in the main thread
-  (with-body-in-main-thread ()
-    (with-init-window (:title "Window test" :width 600 :height 400)
-      (setf %gl:*gl-get-proc-address* #'get-proc-address)
-      (set-key-callback 'quit-on-escape)
-      (set-window-size-callback 'update-viewport)
+  (tmt:with-body-in-main-thread ()
+    (glfw:with-init-window (:title "Window test" :width 600 :height 400)
+      ;(setf %gl:*gl-get-proc-address* #'get-proc-address)
+      (glfw:set-key-callback 'quit-on-escape)
+      (glfw:set-window-size-callback 'update-viewport)
       (gl:clear-color 0 0 0 0)
       (set-viewport 600 400)
-      (loop until (window-should-close-p)
-         do (render)
-         do (swap-buffers)
-         do (poll-events)))))
+
+      (loop until (glfw:window-should-close-p)
+        do (render)
+        do (glfw:swap-buffers)
+        do (glfw:poll-events)))))

--- a/examples/events.lisp
+++ b/examples/events.lisp
@@ -1,47 +1,82 @@
 ;;;; events.lisp
 ;;;; This example shows events in the title bar.
-(in-package #:cl-glfw3-examples)
 
-(export '(events-example))
+(defpackage :cl-glfw3-examples/examples/events
+  (:use #:cl)
+  (:export #:events-example))
 
+(in-package :cl-glfw3-examples/examples/events)
+
+(defparameter *window-size* nil)
 (defparameter *keys-pressed* nil)
 (defparameter *buttons-pressed* nil)
-(defparameter *window-size* nil)
+
+(defmacro deletef (key arr)
+  `(setf ,arr (delete ,key ,arr)))
 
 (defun update-window-title (window)
-  (set-window-title (format nil "size ~A | keys ~A | buttons ~A"
+  (glfw:set-window-title (format nil "size ~A | keys ~A | buttons ~A"
                             *window-size*
                             *keys-pressed*
                             *buttons-pressed*)
                     window))
 
-(def-key-callback key-callback (window key scancode action mod-keys)
+(glfw:def-key-callback key-callback (window key scancode action mod-keys)
   (declare (ignore scancode mod-keys))
+
+  ;; Escape key is pressed
   (when (and (eq key :escape) (eq action :press))
-    (set-window-should-close))
+    (glfw:set-window-should-close))
+
+  ;; Key is pressed?
   (if (eq action :press)
+
+    ;; Add it to the list
     (pushnew key *keys-pressed*)
-    (deletef *keys-pressed* key))
+
+    ;; Remove the key
+    (deletef key *keys-pressed*))
+
+  (format t "Pressing keys:~A~%" *keys-pressed*)
+  (force-output)
+
+  ;; Update the window title
   (update-window-title window))
 
-(def-mouse-button-callback mouse-callback (window button action mod-keys)
+(glfw:def-mouse-button-callback mouse-callback (window button action mod-keys)
   (declare (ignore mod-keys))
+
+  ;; Mouse button pressed?
   (if (eq action :press)
+
+    ;; Add it to the list
     (pushnew button *buttons-pressed*)
-    (deletef *buttons-pressed* button))
+
+    ;; Remove it
+    (deletef button *buttons-pressed*))
+
+  (format t "Pressing mouse buttons:~A~%" *buttons-pressed*)
+  (force-output)
+
+  ;; Update the window title
   (update-window-title window))
 
-(def-window-size-callback window-size-callback (window w h)
+(glfw:def-window-size-callback window-size-callback (window w h)
   (setf *window-size* (list w h))
   (update-window-title window))
 
 (defun events-example ()
   ;; Graphics calls on OS X must occur in the main thread
-  (with-body-in-main-thread ()
-    (with-init-window (:title "" :width 400 :height 400)
-      (set-key-callback 'key-callback)
-      (set-mouse-button-callback 'mouse-callback)
-      (set-window-size-callback 'window-size-callback)
-      (setf *window-size* (get-window-size))
-      (update-window-title *window*)
-      (loop until (window-should-close-p) do (wait-events)))))
+  (tmt:with-body-in-main-thread ()
+    (glfw:with-init-window (:title "No name" :width 400 :height 400)
+
+      ;; Add our event listeners
+      (glfw:set-key-callback 'key-callback)
+      (glfw:set-mouse-button-callback 'mouse-callback)
+      (glfw:set-window-size-callback 'window-size-callback)
+
+      ;; Setup the initial window
+      (setf *window-size* (glfw:get-window-size))
+
+      (update-window-title glfw:*window*)
+      (loop until (glfw:window-should-close-p) do (glfw:wait-events)))))

--- a/examples/package.lisp
+++ b/examples/package.lisp
@@ -1,4 +1,8 @@
-;;;; package.lisp
+(uiop/package:define-package
+  :cl-glfw3-examples/package (:nicknames :cl-glfw3-examples)
+  (:use-reexport
 
-(defpackage #:cl-glfw3-examples
-  (:use #:cl #:glfw #:alexandria #:trivial-main-thread))
+    :cl-glfw3-examples/examples/events
+    :cl-glfw3-examples/examples/basic-window
+    :cl-glfw3-examples/examples/particles-basic
+    :cl-glfw3-examples/examples/fragment-shader))

--- a/examples/particles-basic.lisp
+++ b/examples/particles-basic.lisp
@@ -1,9 +1,11 @@
 ;;;; opengl.lisp
 ;;;; OpenGL example code borrowed from cl-opengl
 
-(in-package #:cl-glfw3-examples)
+(defpackage :cl-glfw3-examples/examples/particles-basic
+  (:use :cl)
+  (:export #:particles-basic-example))
 
-(export '(particles-basic-example))
+(in-package :cl-glfw3-examples/examples/particles-basic)
 
 ;; Try live-editing these variables in Emacs slime
 (defvar color 0)
@@ -43,10 +45,10 @@
 
          (gl:rect -25 -25 25 25))))
 
-(def-key-callback quit-on-escape (window key scancode action mod-keys)
+(glfw:def-key-callback quit-on-escape (window key scancode action mod-keys)
   (declare (ignore window scancode mod-keys))
   (when (and (eq key :escape) (eq action :press))
-    (set-window-should-close)))
+    (glfw:set-window-should-close)))
 
 (defun set-viewport (width height)
   ;; Black background
@@ -66,22 +68,24 @@
   (gl:matrix-mode :modelview)
   (gl:load-identity))
 
-(def-window-size-callback update-viewport (window w h)
+(glfw:def-window-size-callback update-viewport (window w h)
   (declare (ignore window))
   (set-viewport w h))
 
 (defun particles-basic-example ()
   ;; Graphics calls on OS X must occur in the main thread
-  (with-body-in-main-thread ()
-    (with-init-window (:title "OpenGL particle test" :width 600 :height 400)
-      (set-key-callback 'quit-on-escape)
+  (tmt:with-body-in-main-thread ()
+    (glfw:with-init-window (:title "OpenGL particle test" :width 600 :height 400)
+      (glfw:set-key-callback 'quit-on-escape)
 
       ;; Callback for window resize events
-      (set-window-size-callback 'update-viewport)
+      (glfw:set-window-size-callback 'update-viewport)
+
+      ;; Setup the renderer
       (set-viewport 800 400)
 
       ;; Our render-loop
-      (loop until (window-should-close-p)
+      (loop until (glfw:window-should-close-p)
             do (render)
-            do (swap-buffers)
-            do (poll-events)))))
+            do (glfw:swap-buffers)
+            do (glfw:poll-events)))))

--- a/examples/run-all.lisp
+++ b/examples/run-all.lisp
@@ -1,8 +1,9 @@
 (ql:quickload :cl-glfw3-examples)
 
-(cl-glfw3-examples:events-example)
+;(cl-glfw3-examples:events-example)
 (cl-glfw3-examples:basic-window-example)
-(cl-glfw3-examples:particles-basic-example)
-(cl-glfw3-examples:fragment-shader-example)
+;(cl-glfw3-examples:particles-basic-example)
+;(cl-glfw3-examples:fragment-shader-example)
 
+; (quit)
 (format t "~%Welcome to cl-glfw3.~%")

--- a/examples/run-all.lisp
+++ b/examples/run-all.lisp
@@ -1,0 +1,8 @@
+(ql:quickload :cl-glfw3-examples)
+
+(cl-glfw3-examples:events-example)
+(cl-glfw3-examples:basic-window-example)
+(cl-glfw3-examples:particles-basic-example)
+(cl-glfw3-examples:fragment-shader-example)
+
+(format t "~%Welcome to cl-glfw3.~%")

--- a/examples/run-all.lisp
+++ b/examples/run-all.lisp
@@ -1,9 +1,8 @@
 (ql:quickload :cl-glfw3-examples)
 
-;(cl-glfw3-examples:events-example)
+(cl-glfw3-examples:events-example)
 (cl-glfw3-examples:basic-window-example)
-;(cl-glfw3-examples:particles-basic-example)
-;(cl-glfw3-examples:fragment-shader-example)
+(cl-glfw3-examples:particles-basic-example)
+(cl-glfw3-examples:fragment-shader-example)
 
-; (quit)
 (format t "~%Welcome to cl-glfw3.~%")


### PR DESCRIPTION
I found it restricting that the arguments to `with-init-window` should be a hard-coded list.

```lisp
(defun my-parameter-generator () 
  '(:width 100 :height 100 :title "My Test Window"))

(with-init-window-from-list (my-parameter-generator)
  (loop ...))
```
Or:
```lisp
(with-init-window-from-list (list :width 100 :height 100 :title "My title")
  (loop ...))
```