### PR TITLE
add window size limits functions

### DIFF
--- a/cl-glfw3.lisp
+++ b/cl-glfw3.lisp
@@ -33,6 +33,8 @@
    set-window-position
    get-window-size
    set-window-size
+   set-window-size-limits
+   set-window-aspect-ratio
    set-window-monitor
    get-framebuffer-size
    iconify-window
@@ -236,6 +238,12 @@ SHARED: The window whose context to share resources with."
 
 (defun set-window-size (w h &optional (window *window*))
   (%glfw:set-window-size window w h))
+
+(defun set-window-size-limits (minwidth minheight maxwidth maxheight &optional (window *window*))
+  (%glfw:set-window-size-limits window minwidth minheight maxwidth maxheight))
+
+(defun set-window-aspect-ratio (width height &optional (window *window*))
+  (%glfw:set-window-aspect-ratio window width height))
 
 (defun get-framebuffer-size (&optional (window *window*))
   (%glfw:get-framebuffer-size window))

--- a/glfw-bindings.lisp
+++ b/glfw-bindings.lisp
@@ -38,6 +38,8 @@
    set-window-position
    get-window-size
    set-window-size
+   set-window-size-limits
+   set-window-aspect-ratio
    get-framebuffer-size
    iconify-window
    restore-window
@@ -560,6 +562,12 @@ Returns previously set callback."
 
 (defcfun ("glfwSetWindowSize" set-window-size) :void
   (window window) (w :int) (h :int))
+
+(defcfun ("glfwSetWindowSizeLimits" set-window-size-limits) :void
+  (window window) (minwidth :int) (minheight :int) (maxwidth :int) (maxheight :int))
+
+(defcfun ("glfwSetWindowAspectRatio" set-window-aspect-ratio) :void
+  (window window) (width :int) (height :int))
 
 (defun get-framebuffer-size (window)
   "Returns size (w h) of framebuffer in pixels."


### PR DESCRIPTION
> The minimum and maximum size of the client area of a windowed mode window can be enforced with `glfwSetWindowSizeLimits`

> The aspect ratio of the client area of a windowed mode window can be enforced with `glfwSetWindowAspectRatio`

here is the [document](https://www.glfw.org/docs/latest/window_guide.html#window_sizelimits)