### PR TITLE
Add getters for content scale and monitor work area.

### DIFF
--- a/cl-glfw3.lisp
+++ b/cl-glfw3.lisp
@@ -36,6 +36,7 @@
    set-window-size-limits
    set-window-aspect-ratio
    set-window-monitor
+   get-window-content-scale
    get-framebuffer-size
    iconify-window
    restore-window
@@ -123,7 +124,7 @@
      (unwind-protect (progn ,@body)
        (%glfw:terminate))))
 
-(import-export %glfw:get-monitors %glfw:get-primary-monitor %glfw:get-monitor-physical-size %glfw:get-monitor-name %glfw:set-monitor-callback %glfw:get-video-modes %glfw:get-video-mode %glfw:set-gamma %glfw:get-gamma-ramp %glfw:set-gamma-ramp %glfw:terminate)
+(import-export %glfw:get-monitors %glfw:get-primary-monitor %glfw:get-monitor-position %glfw:get-monitor-work-area %glfw:get-monitor-physical-size %glfw:get-monitor-content-scale %glfw:get-monitor-name %glfw:set-monitor-callback %glfw:get-video-modes %glfw:get-video-mode %glfw:set-gamma %glfw:get-gamma-ramp %glfw:set-gamma-ramp %glfw:terminate)
 
 (defmacro def-monitor-callback (name (monitor event) &body body)
   `(%glfw:define-glfw-callback ,name
@@ -244,6 +245,9 @@ SHARED: The window whose context to share resources with."
 
 (defun set-window-aspect-ratio (width height &optional (window *window*))
   (%glfw:set-window-aspect-ratio window width height))
+
+(defun get-window-content-scale (&optional (window *window*))
+  (%glfw:get-window-content-scale window))
 
 (defun get-framebuffer-size (&optional (window *window*))
   (%glfw:get-framebuffer-size window))

--- a/glfw-bindings.lisp
+++ b/glfw-bindings.lisp
@@ -14,7 +14,9 @@
    get-monitors
    get-primary-monitor
    get-monitor-position
+   get-monitor-work-area
    get-monitor-physical-size
+   get-monitor-content-scale
    get-monitor-name
    set-monitor-callback
    get-video-modes
@@ -40,6 +42,7 @@
    set-window-size
    set-window-size-limits
    set-window-aspect-ratio
+   get-window-content-scale
    get-framebuffer-size
    iconify-window
    restore-window
@@ -466,12 +469,26 @@ Returns the previous error callback."
 		     monitor monitor :pointer x :pointer y :void)
     (list (mem-ref x :int) (mem-ref y :int))))
 
+(defun get-monitor-work-area (monitor)
+  "Returned work area is (x y w h) in screen coordinates."
+  (with-foreign-objects ((x :int) (y :int) (w :int) (h :int))
+    (foreign-funcall "glfwGetMonitorWorkarea"
+                     monitor monitor :pointer x :pointer y :pointer w :pointer h :void)
+    (list (mem-ref x :int) (mem-ref y :int) (mem-ref w :int) (mem-ref h :int))))
+
 (defun get-monitor-physical-size (monitor)
   "Returned size is (w h) in mm."
   (with-foreign-objects ((w :int) (h :int))
     (foreign-funcall "glfwGetMonitorPhysicalSize"
 		     monitor monitor :pointer w :pointer h :void)
     (list (mem-ref w :int) (mem-ref h :int))))
+
+(defun get-monitor-content-scale (monitor)
+  "Returned scale is (x-scale y-scale)."
+  (with-foreign-objects ((x-scale :float) (y-scale :float))
+    (foreign-funcall  "glfwGetMonitorContentScale"
+                      monitor monitor :pointer x-scale :pointer y-scale :void)
+    (list (mem-ref x-scale :float) (mem-ref y-scale :float))))
 
 (defcfun ("glfwGetMonitorName" get-monitor-name) :string
   (monitor monitor))
@@ -568,6 +585,13 @@ Returns previously set callback."
 
 (defcfun ("glfwSetWindowAspectRatio" set-window-aspect-ratio) :void
   (window window) (width :int) (height :int))
+
+(defun get-window-content-scale (window)
+  "Returned scale is (x-scale y-scale)."
+  (with-foreign-objects ((x-scale :float) (y-scale :float))
+    (foreign-funcall  "glfwGetWindowContentScale"
+                      window window :pointer x-scale :pointer y-scale :void)
+    (list (mem-ref x-scale :float) (mem-ref y-scale :float))))
 
 (defun get-framebuffer-size (window)
   "Returns size (w h) of framebuffer in pixels."


### PR DESCRIPTION
Added GLFW 3.3 bindings for:

[glfwGetWindowContentScale](https://www.glfw.org/docs/latest/group__window.html#gaf5d31de9c19c4f994facea64d2b3106c)
[glfwGetMonitorContentScale](https://www.glfw.org/docs/latest/group__monitor.html#gad3152e84465fa620b601265ebfcdb21b)
[glfwGetMonitorWorkarea](https://www.glfw.org/docs/latest/group__monitor.html#ga7387a3bdb64bfe8ebf2b9e54f5b6c9d0)

Also added `get-monitor-position` to the import-export list.