### PR TITLE
Return window from make-context-current, and in turn create-window.

### DIFF
--- a/cl-glfw3.lisp
+++ b/cl-glfw3.lisp
@@ -447,7 +447,8 @@ SHARED: The window whose context to share resources with."
 ;;;; ## Context
 (defun make-context-current (window)
   (setf *window* window)
-  (%glfw:make-context-current window))
+  (%glfw:make-context-current window)
+  window)
 
 (defun get-current-context ()
   (%glfw:get-current-context))


### PR DESCRIPTION
This makes create-window return a window object.

I needed this change in order to use multiple-windows.