### PR TITLE
Add Vulkan support

### DIFF
--- a/cl-glfw3.lisp
+++ b/cl-glfw3.lisp
@@ -193,8 +193,9 @@ SHARED: The window whose context to share resources with."
   (let ((window (%glfw:create-window width height title monitor shared)))
     (if (cffi:null-pointer-p window)
 	(error "Error creating window.")
-	(unless (eq client-api :no-api)
-          (make-context-current window)))))
+	(if (eq client-api :no-api)
+            (setf *window* window)
+            (make-context-current window)))))
 
 (defun destroy-window (&optional (window *window*))
   (when window (%glfw:destroy-window window))

--- a/cl-glfw3.lisp
+++ b/cl-glfw3.lisp
@@ -193,7 +193,8 @@ SHARED: The window whose context to share resources with."
   (let ((window (%glfw:create-window width height title monitor shared)))
     (if (cffi:null-pointer-p window)
 	(error "Error creating window.")
-	(make-context-current window))))
+	(unless (eq client-api :no-api)
+          (make-context-current window)))))
 
 (defun destroy-window (&optional (window *window*))
   (when window (%glfw:destroy-window window))
@@ -460,4 +461,11 @@ SHARED: The window whose context to share resources with."
 (defun swap-buffers (&optional (window *window*))
   (%glfw:swap-buffers window))
 
-(import-export %glfw:swap-interval %glfw:extension-supported-p %glfw:get-proc-address)
+(import-export %glfw:swap-interval
+               %glfw:extension-supported-p
+               %glfw:get-proc-address
+               %glfw:vulkan-supported-p
+               %glfw:get-required-instance-extensions
+               %glfw:get-instance-proc-address
+               %glfw:physical-device-presentation-support-p
+               %glfw:create-window-surface)

--- a/glfw-bindings.lisp
+++ b/glfw-bindings.lisp
@@ -814,7 +814,7 @@ Returns previously set callback."
   (queue-family :uint32))
 
 (defun create-window-surface (instance &optional (window *window*) (allocator (cffi:null-pointer)))
-  (cffi:with-foreign-object (surface-khr vk-surface-khr)
+  (cffi:with-foreign-object (surface-khr 'vk-surface-khr)
     (let ((result (foreign-funcall "glfwCreateWindowSurface"
                                    vk-instance instance
                                    window window

--- a/glfw-bindings.lisp
+++ b/glfw-bindings.lisp
@@ -88,7 +88,12 @@
    swap-buffers
    swap-interval
    extension-supported-p
-   get-proc-address))
+   get-proc-address
+   vulkan-supported-p
+   get-required-instance-extensions
+   get-instance-proc-address
+   physical-device-presentation-support-p
+   create-window-surface))
 
 ;; internal stuff
 (export
@@ -390,6 +395,7 @@ CFFI's defcallback that takes care of GLFW specifics."
   (:opengl-profile #X00022008))
 
 (defcenum (opengl-api)
+  (:no-api 0)
   (:opengl-api #X00030001)
   (:opengl-es-api #X00030002))
 
@@ -417,6 +423,12 @@ CFFI's defcallback that takes care of GLFW specifics."
   (:hidden #X00034002)
   (:disabled #X00034003))
 
+(defcenum (vk-result :int)
+  (:error-native-window-in-use-khr -1000000001) ;; returned by glfwCreateWindowSurface if the window has not been created with GLFW_NO_API
+  (:error-extension-not-present -7) ;; returned by glfwCreateWindowSurface if the required extensions have not been enabled on the VkInstance
+  (:error-initialization-failed -3) ;; returned by glfwCreateWindowSurface if Vulkan is not supported on the system
+  (:success #x0)) ;; returned by glfwCreateWindowSurface if the VkSurfaceKHR has been created successfully
+
 (defcstruct video-mode
   (width :int)
   (height :int)
@@ -433,6 +445,14 @@ CFFI's defcallback that takes care of GLFW specifics."
 
 (defctype window :pointer)
 (defctype monitor :pointer)
+
+;; vulkan handles
+(defctype vk-instance :pointer)
+#.(if (= 8 (foreign-type-size :pointer))
+      '(defctype vk-surface-khr :pointer)
+      '(defctype vk-surface-khr :uint64))
+(defctype vk-physical-device :pointer)
+(defctype vk-allocation-callbacks :pointer)
 
 ;;;; ## GLFW Functions
 (defcfun ("glfwInit" init) :boolean)
@@ -772,3 +792,35 @@ Returns previously set callback."
 
 (defcfun ("glfwGetProcAddress" get-proc-address) :pointer
   (proc-name :string))
+
+(defcfun ("glfwVulkanSupported" vulkan-supported-p) :boolean)
+
+(defun get-required-instance-extensions ()
+  "Returns a all names of required Vulkan extensions in a list."
+  (with-foreign-object (count :int)
+    (c-array->list (foreign-funcall "glfwGetRequiredInstanceExtensions"
+				    :pointer count
+                                    :pointer)
+        (mem-ref count :int)
+        :string)))
+
+(defcfun ("glfwGetInstanceProcAddress" get-instance-proc-address) :pointer
+  (instance vk-instance)
+  (proc-name :string))
+
+(defcfun ("glfwGetPhysicalDevicePresentationSupport" physical-device-presentation-support-p) :boolean
+  (instance vk-instance)
+  (device vk-physical-device)
+  (queue-family :uint32))
+
+(defun create-window-surface (instance &optional (window *window*) (allocator (cffi:null-pointer)))
+  (cffi:with-foreign-object (surface-khr vk-surface-khr)
+    (let ((result (foreign-funcall "glfwCreateWindowSurface"
+                                   vk-instance instance
+                                   window window
+                                   vk-allocation-callbacks allocator
+                                   vk-surface-khr surface-khr
+                                   vk-result)))
+      (if (eq result :success)
+          (cffi:mem-aref surface-khr 'vk-surface-khr)
+          (error "Error creating VkSurfaceKHR: ~a" result)))))

--- a/glfw-bindings.lisp
+++ b/glfw-bindings.lisp
@@ -448,6 +448,8 @@ CFFI's defcallback that takes care of GLFW specifics."
 
 ;; vulkan handles
 (defctype vk-instance :pointer)
+;; VkSurfaceKHR is a non-dispatchable handle - type depends on the system
+;; see: https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VK_DEFINE_NON_DISPATCHABLE_HANDLE.html
 #.(if (= 8 (foreign-type-size :pointer))
       '(defctype vk-surface-khr :pointer)
       '(defctype vk-surface-khr :uint64))


### PR DESCRIPTION
I've added all functions (and required types) listed here: https://www.glfw.org/docs/3.3/group__vulkan.html

I've also changed `with-init-window` so that it doesn't call `make-context-current` if `:client-api` is `:no-api` since the window obviously doesn't have an OpenGL context in that case, causing `glfwMakeContextCurrent` to throw an error.